### PR TITLE
Ignore PR's from `github-actions` bot

### DIFF
--- a/api/pr.py
+++ b/api/pr.py
@@ -78,7 +78,7 @@ async def opened_pr(event, gh, *arg, **kwargs):
     members = [m["login"] for m in members]
 
     user = pull_request["user"]["login"]
-    if 'dependabot' in user or "paperless-l10n" in user:
+    if "dependabot" in user or "paperless-l10n" in user or "github-actions" in user:
         print(f"ignoring PR from {user}")
         return
 


### PR DESCRIPTION
This should prevent comments like https://github.com/paperless-ngx/paperless-ngx/pull/1298#issuecomment-1198725461, where the changelog is automatically updated from a GitHub Actions run, and the `github-actions` bot creates a PR.

This is only a quick addition and not tested. Please double check.