### PR TITLE
Make all docs changes small

### DIFF
--- a/api/pr.py
+++ b/api/pr.py
@@ -35,7 +35,7 @@ def get_responsible_teams(diff):
 
 def get_change_size(diff):
     size = 0
-    ignore_types = ["md", "txt", "lock"]
+    ignore_types = ["rst", "md", "txt", "lock"]
     for change in diff:
         if change.path.split(".")[-1] not in ignore_types:
             for hunk in change:


### PR DESCRIPTION
`md` files were already in the list, but the docs use `rst`.

Honestly, the `small-change` and `non-trivial` labels should not be added on these types maybe?
Otherwise, if the idea is to ensure several people have to sign off a bigger change (including docs), then `md` should probably also not be excluded here.